### PR TITLE
add docker-compose to run Jekyll locally

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ kramdown:
    auto_ids: true
    entity_output: numeric
    hard_wrap: false
-exclude: [ README.md, Gemfile, psd ]
+exclude: [ README.md, Gemfile, psd, docker-compose.yml ]
 navigation:
  - title: Documentation
    url: /documentation/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  jekyll:
+    image: jekyll/jekyll:4.2.0
+    volumes:
+      - .:/srv/jekyll
+    ports:
+      - "4000:4000"
+    command: jekyll serve --force_polling --drafts
+    environment:
+      JEKYLL_ROOTLESS: ${JEKYLL_ROOTLESS:-0}


### PR DESCRIPTION
Allows to run a local Jekyll server using Docker.

Start server:
```bash
docker compose -f ./docker-compose.yml up
```

Works in rootles mode too:
```bash
JEKYLL_ROOTLESS=1 docker compose -f ./docker-compose.yml up
```

Page will be available at localhost:4000